### PR TITLE
feature/58283

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/preset-env"],
+    "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+dist
+.env
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,69 @@
+{
+    "name": "apollo-sever",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "dependencies": {
+        "apollo-server-express": "^2.19.1",
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "express": "^4.17.1",
+        "graphql": "^15.4.0",
+        "merge-graphql-schemas": "^1.7.8",
+        "path": "^0.12.7",
+        "dotenv": "^8.2.0"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.12.10",
+        "@babel/node": "^7.12.10",
+        "@babel/preset-env": "^7.12.11",
+        "eslint": "^7.17.0",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "eslint-plugin-import": "^2.22.1",
+        "nodemon": "^2.0.7",
+        "tsc-watch": "^4.2.9"
+    },
+    "scripts": {
+        "start": "nodemon --exec babel-node src",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "nodemon": "nodemon ./dist/index.js ",
+        "lint": "eslint src",
+        "lint:fix": "npm run lint --fix"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/saransh-kumar/apollo-sever.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/saransh-kumar/apollo-sever/issues"
+    },
+    "homepage": "https://github.com/saransh-kumar/apollo-sever#readme",
+    "eslintConfig": {
+        "extends": "airbnb-base",
+        "env": {
+            "es6": true,
+            "browser": true
+        },
+        "rules": {
+            "brace-style": [
+                "error",
+                "stroustrup"
+            ],
+            "comma-dangle": [
+                "error",
+                "never"
+            ],
+            "no-unused-vars": [
+                "warn"
+            ],
+            "no-var": [
+                "off"
+            ],
+            "one-var": [
+                "off"
+            ]
+        }
+    }
+}

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -1,0 +1,14 @@
+import pkg from 'dotenv';
+
+// eslint-disable-next-line import/no-mutable-exports
+let { config } = pkg;
+
+config();
+
+const envVars = process.env;
+config = Object.freeze({
+  NODE_ENV: envVars.NODE_ENV,
+  PORT: envVars.PORT
+
+});
+export default config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/extensions */
+import Server from './server.js';
+import config from './config/configuration.js';
+import schema from './module/index.js';
+
+const server = new Server(config);
+(() => {
+  server.bootstrap().setupApollo(schema);
+})();

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -1,0 +1,20 @@
+import { fileLoader, mergeTypes } from 'merge-graphql-schemas';
+import path from 'path';
+// eslint-disable-next-line import/extensions
+import * as user from './user/index.js';
+
+// eslint-disable-next-line no-underscore-dangle
+const __dirname = path.resolve();
+
+const typesArray = fileLoader(path.join(__dirname, './**/*.graphql'));
+
+const typeDefs = mergeTypes(typesArray, { all: true });
+
+export default {
+  resolvers: {
+    Query: {
+      ...user.Query
+    }
+  },
+  typeDefs
+};

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+    getMyProfile: User!
+}

--- a/src/module/user/index.js
+++ b/src/module/user/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/extensions */
+/* eslint-disable import/prefer-default-export */
+export { default as Query } from './query.js';

--- a/src/module/user/query.js
+++ b/src/module/user/query.js
@@ -1,0 +1,9 @@
+export default {
+  getMyProfile: () => (
+    {
+      id: 1,
+      name: 'Saransh Kumar',
+      email: 'saransh.kumar@successive.tech'
+    }
+  )
+};

--- a/src/module/user/types.graphql
+++ b/src/module/user/types.graphql
@@ -1,0 +1,5 @@
+type User {
+    id: ID!
+    name: String!
+    email: String!
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,45 @@
+import Express from 'express';
+import { ApolloServer } from 'apollo-server-express';
+
+class Server {
+  constructor(config) {
+    this.config = config;
+    console.log('config: ', config);
+    this.app = Express();
+  }
+
+  bootstrap() {
+    // this.setupApollo(schema);
+    // return this;
+    this.setupRouts();
+    return this;
+  }
+
+  setupRouts() {
+    const { app } = this;
+    app.get('/health-check', (req, res) => {
+      res.send('I am fine');
+    });
+    return this;
+  }
+
+  setupApollo(schema) {
+    const { app } = this;
+    this.Server = new ApolloServer({
+      ...schema
+    });
+    this.Server.applyMiddleware({ app });
+    this.run();
+  }
+
+  run() {
+    const { app, config: { PORT } } = this;
+    app.listen(PORT, (err) => {
+      if (err) {
+        console.log(err);
+      }
+      console.log(`App is running on PORT ${PORT}`);
+    });
+  }
+}
+export default Server;


### PR DESCRIPTION
# [Apollo GraphQL] Day 2: Bootstrapping Apollo Server and Queries

Steps

Add type for User in user/types.graphql file and define schema for id, name, and email address.
Add type query getMyProfile in modules/schema.graphql file and add its return type as User.
Add resolver getMyProfile in user/query.js file and return your information (name, email and id).
Combine all of the graphql file to create a schema.
Create an index file in src/modules folder and import fileLoader and mergeTypes from merge-graphql-schemas.
With fileLoader get all the .graphl files and merge them with the help of mergeTypes.
import the user module's query and export a single object with typeDefs and resolver. 
Configure the server just like you did in express application.
Create an extra function called setupApollo, where you will create an instance of apollo server and you will add that as middleware to your express application
Add the config folder and export your environment variables.
Bootstrap the express server, call setupApollo and start the server.
