### PR TITLE
feature/58498

### DIFF
--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -9,6 +9,5 @@ const envVars = process.env;
 config = Object.freeze({
   NODE_ENV: envVars.NODE_ENV,
   PORT: envVars.PORT
-
 });
 export default config;

--- a/src/lib/constant.js
+++ b/src/lib/constant.js
@@ -1,0 +1,7 @@
+export default {
+  subscriptions: {
+    TRAINEE_ADDED: 'TRAINEE_ADDED',
+    TRAINEE_UPDATED: 'TRAINEE_UPDATED',
+    TRAINEE_DELETED: 'TRAINEE_DELETED'
+  }
+};

--- a/src/module/index.js
+++ b/src/module/index.js
@@ -18,6 +18,9 @@ export default {
     },
     Mutation: {
       ...trainee.Mutation
+    },
+    Subscription: {
+      ...trainee.Subscription
     }
   },
   typeDefs

--- a/src/module/pubsub.js
+++ b/src/module/pubsub.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
+import { PubSub } from 'apollo-server-express';
+
+export default new PubSub();

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -9,3 +9,9 @@ type Mutation {
     updateTrainee(id: ID!, role: String): User!
     deleteTrainee(id: ID!): ID!
 }
+
+type Subscription {
+    traineeAdded: User!
+    traineeUpdated: User!
+    traineeDeleted: ID!
+}

--- a/src/module/trainee/index.js
+++ b/src/module/trainee/index.js
@@ -1,2 +1,3 @@
 export { default as Mutation } from './mutation';
 export { default as Query } from './query';
+export { default as Subscription } from './subscription';

--- a/src/module/trainee/mutation.js
+++ b/src/module/trainee/mutation.js
@@ -1,18 +1,25 @@
+/* eslint-disable import/no-duplicates */
 import userInstance from '../../service/user';
+import pubsub from '../pubsub';
+import constant from '../../lib/constant';
 
 export default {
-  createTrainee: (parent, args, context) => {
+  createTrainee: (parent, args) => {
     const { user } = args;
-    return userInstance.createUser(user);
+    const addedUser = userInstance.createUser(user);
+    pubsub.publish(constant.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
+    return addedUser;
   },
-  updateTrainee: (parent, args, context) => {
-    const {
-      id, role
-    } = args;
-    return userInstance.updateUser(id, role);
+  updateTrainee: (parent, args) => {
+    const { id, role } = args;
+    const updatedUser = userInstance.updateUser(id, role);
+    pubsub.publish(constant.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
+    return updatedUser;
   },
-  deleteTrainee: (parent, args, context) => {
+  deleteTrainee: (parent, args) => {
     const { id } = args;
-    return userInstance.deleteUser(id);
+    const deletedId = userInstance.deleteUser(id);
+    pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedId });
+    return deletedId;
   }
 };

--- a/src/module/trainee/subscription.js
+++ b/src/module/trainee/subscription.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable import/extensions */
+import constant from '../../lib/constant';
+import pubsub from '../pubsub';
+
+export default {
+  traineeAdded: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_ADDED])
+  },
+  traineeUpdated: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_UPDATED])
+  },
+  traineeDeleted: {
+    subscribe: () => pubsub.asyncIterator([constant.subscriptions.TRAINEE_DELETED])
+  }
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,7 @@
+/* eslint-disable no-console */
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import { createServer } from 'http';
 
 class Server {
   constructor(config) {
@@ -30,16 +32,18 @@ class Server {
       ...schema
     });
     this.Server.applyMiddleware({ app });
+    this.httpServer = createServer(app);
+    this.Server.installSubscriptionHandlers(this.httpServer);
     this.run();
   }
 
   run() {
-    const { app, config: { PORT } } = this;
-    app.listen(PORT, (err) => {
+    const { config: { PORT } } = this;
+    this.httpServer.listen(PORT, (err) => {
       if (err) {
         console.log(err);
       }
-      console.log(`App is running on PORT ${PORT}`);
+      console.log(`APP is running on PORT ${PORT}`);
     });
   }
 }

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 class User {
   constructor() {
     this.users = new Map();


### PR DESCRIPTION
**[Apollo GraphQL] Day 4: Subscriptions**

Prerequisites

Add apollo-server package
Add subscription middleware to the apollo server.
Steps

Add a file called pubsub.js inside the module folder where you have to import the Pubsub class from the apollo server and export its instance.
Add the subscription type with addTrainee, updateTrainee, and deleteTrainee with return types as User for the first two and ID for the last one.
Add a file named subscription.js inside the trainee module.
Import Pubsub instance from pubsub.js
Define all the pubsub methods on the basis of topic.
From your mutations publish your data, for example, publish data for created Trainee on createTrainee topic.
The last step would be updating the server.js file so that it starts accepting WebSocket requests.
Import createServer from the HTTP module.
Call the create server with the express app as an argument.
Pass the newly created server instance as an argument to the installSubscriptionsHandlers method of the apollo server instance.
Update the run method so that it starts the server using the newly created server instance.