### PR TITLE
feature/58720

### DIFF
--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -7,8 +7,8 @@ export default class TraineeAPI extends RESTDataSource {
     this.baseURL = `${configurations.SERVICE_URL}/api/trainee`;
   }
 
-  async getTrainees() {
-    return this.get('/');
+  async getTrainees(skip, limit, sortedBy, sortedOrder) {
+    return this.get(`/?sortedBy=${sortedBy}&limit=${limit}&skip=${skip}&sortedOrder=${sortedOrder}`);
   }
 
   async createTrainee(payload) {
@@ -16,12 +16,10 @@ export default class TraineeAPI extends RESTDataSource {
   }
 
   async updateTrainee(payload) {
-    console.log('Payload', payload);
     return this.put('/', payload);
   }
 
   deleteTrainee(payload) {
-    console.log('Payload: ', payload);
     return this.delete(`/${payload.originalId}`, payload);
   }
 }

--- a/src/module/schema.graphql
+++ b/src/module/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
     getMyProfile: User!
-    getAllTrainees: [User]
+    getAllTrainees(payload: GetInput): TRAINEELIST
     getTrainee(id: ID!): User!
 }
 

--- a/src/module/trainee/mutation.js
+++ b/src/module/trainee/mutation.js
@@ -19,11 +19,9 @@ export default {
   },
   deleteTrainee: async (parent, args, context) => {
     const { originalId } = args;
-    console.log(originalId);
     const { dataSources: { traineeAPI } } = context;
     const deletedId = await traineeAPI.deleteTrainee({ originalId });
     pubsub.publish(constant.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedId });
-    console.log(deletedId);
     return deletedId.message;
   }
 };

--- a/src/module/trainee/query.js
+++ b/src/module/trainee/query.js
@@ -3,8 +3,13 @@ import user from '../../service/user';
 export default {
   getAllTrainees: async (parent, args, context) => {
     const { dataSources: { traineeAPI } } = context;
-    const response = await traineeAPI.getTrainees();
-    return response.data.records;
+    const {
+      payload: {
+        skip, limit, sortedBy, sortedOrder
+      }
+    } = args;
+    const response = await traineeAPI.getTrainees(skip, limit, sortedBy, sortedOrder);
+    return response.data;
   },
   getTrainee: (parent, args) => {
     const { id } = args;

--- a/src/module/trainee/types.graphql
+++ b/src/module/trainee/types.graphql
@@ -16,3 +16,10 @@ input UpdateUser {
     email: String
     role: String
 }
+
+input GetInput {
+    skip: String
+    limit: String
+    sortedBy: String
+    sortedOrder: String
+}

--- a/src/module/user/types.graphql
+++ b/src/module/user/types.graphql
@@ -1,6 +1,22 @@
+scalar Date
+
 type User {
     originalId: ID!
     name: String
     email: String
     role: String
+}
+
+type TRAINEELIST {
+    totalCount: String
+    records: [ALLFIELD]
+}
+
+type ALLFIELD {
+    _id: String
+    name: String
+    email: String
+    role: String
+    originalId: String
+    createdAt: Date
 }


### PR DESCRIPTION
**[Apollo GraphQL] Day 8: Querying the list**

AC
Replace the API for fetching trainee list with Graph API call with the help of the Query component.

Prerequisites

Install the package apollo-link-context.
Configuring the apollo client to send request headers.
In your lib/graphql-client file import setContext from the above package.
Call the setContext method and pass a callback which will be responsible for appending the headers for all requests.
Pass the above-created context as a link argument to the Apollo Client instance and call the available context's concat method with the HTTP link variable as an argument.
Steps

Add Query getTrainee query in query.js file in pages/trainee module.
Use the graphql HOC from @apollo/react-hoc package for doing the query.
Wrap trainee list component with graphql HOC and pass the query as well as required variables as parameters.
Update the logic for generating listing accordingly.
Replace the logic for pagination with Refetch API.